### PR TITLE
bugfix: distangle big brain cyto brain from MRI

### DIFF
--- a/src/res/ext/atlas/atlas_multiLevelHuman.json
+++ b/src/res/ext/atlas/atlas_multiLevelHuman.json
@@ -58,7 +58,7 @@
       "name": "Big Brain (Histology)",
       "availableIn": [
         {
-          "@id": "minds/core/parcellationatlas/v1.0.0/94c1125b-b87e-45e4-901c-00daee7f2579",
+          "@id": "juelich/iav/atlas/v1.0.0/7",
           "name": "Cytoarchitectonic maps"
         },
         {
@@ -74,14 +74,33 @@
   ],
   "parcellations": [
     {
-      "@id": "minds/core/parcellationatlas/v1.0.0/94c1125b-b87e-45e4-901c-00daee7f2579",
+      "@id": "juelich/iav/atlas/v1.0.0/7",
       "name": "Cytoarchitectonic maps",
       "baseLayer": true,
+      "@version": {
+        "@next": null,
+        "this": "juelich/iav/atlas/v1.0.0/7",
+        "name": "v2.4",
+        "@previous": null
+      },
       "availableIn": [
         {
           "@id": "minds/core/referencespace/v1.0.0/a1655b99-82f1-420f-a3c2-fe80fd4c8588",
           "name": "Big Brain (Histology)"
-        },
+        }
+      ]
+    },
+    {
+      "@id": "minds/core/parcellationatlas/v1.0.0/94c1125b-b87e-45e4-901c-00daee7f2579",
+      "name": "Cytoarchitectonic maps",
+      "baseLayer": true,
+      "@version": {
+        "@next": null,
+        "this": "minds/core/parcellationatlas/v1.0.0/94c1125b-b87e-45e4-901c-00daee7f2579",
+        "name": "v2.4",
+        "@previous": null
+      },
+      "availableIn": [
         {
           "@id": "minds/core/referencespace/v1.0.0/dafcffc5-4826-4bf1-8ff6-46b8a31ff8e2",
           "name": "MNI 152 ICBM 2009c Nonlinear Asymmetric",

--- a/src/res/ext/bigbrain.json
+++ b/src/res/ext/bigbrain.json
@@ -15,8 +15,8 @@
   "nehubaConfigURL": "nehubaConfig/bigbrainNehubaConfig",
   "parcellations": [
     {
-      "@id": "minds/core/parcellationatlas/v1.0.0/94c1125b-b87e-45e4-901c-00daee7f2579",
-      "fullId": "minds/core/parcellationatlas/v1.0.0/94c1125b-b87e-45e4-901c-00daee7f2579",
+      "@id": "juelich/iav/atlas/v1.0.0/7",
+      "fullId": "juelich/iav/atlas/v1.0.0/7",
       "name": "Cytoarchitectonic Maps",
       "properties": {
         "name": "Cytoarchitectonic Maps",

--- a/src/services/state/viewerState/selectors.spec.ts
+++ b/src/services/state/viewerState/selectors.spec.ts
@@ -52,14 +52,15 @@ describe('viewerState/selector.ts', () => {
 
 
     it('> if atlas has basic layer, should return non empty array, if non basic layer is selected', () => {
+      const parc = humanAtlasJson.parcellations.find(p => !p['baseLayer'])
       const multihumanParcs = viewerStateGetOverlayingAdditionalParcellations.projector({
         fetchedAtlases,
         selectedAtlasId: humanAtlasJson['@id']
       }, {
-        parcellationSelected: humanAtlasJson.parcellations[1]
+        parcellationSelected: parc
       })
       expect(multihumanParcs.length).toEqual(1)
-      expect(multihumanParcs[0]['@id']).toEqual(humanAtlasJson.parcellations[1]['@id'])
+      expect(multihumanParcs[0]['@id']).toEqual(parc['@id'])
     })
 
     it('> if atlas has basic layer, but has basic layer selected, should return empty array', () => {

--- a/src/services/state/viewerState/selectors.ts
+++ b/src/services/state/viewerState/selectors.ts
@@ -119,7 +119,7 @@ export const viewerStateAtlasParcellationSelector = createSelector(
     const allParcellations = fetchedTemplates.reduce(flattenFetchedTemplatesIntoParcellationsReducer, [])
 
     const selectedAtlas = selectedAtlasId && fetchedAtlases.find(a => a['@id'] === selectedAtlasId)
-    const atlasLayers =  selectedAtlas?.parcellations
+    const atlasLayers = selectedAtlas?.parcellations
       .map(p => {
         const otherHalfOfParc = allParcellations.find(parc => parc['@id'] === p['@id']) || {}
         return {


### PR DESCRIPTION
on merge object, the originDataset property gets overwritten.
over SANDS, there probably should be three separate atlas versions.
one for each of the template spaces

fixes #708 