### PR TITLE
bugfix: 3d landmarks in slice views

### DIFF
--- a/src/ui/nehubaContainer/nehubaContainer.component.ts
+++ b/src/ui/nehubaContainer/nehubaContainer.component.ts
@@ -437,7 +437,8 @@ export class NehubaContainer implements OnInit, OnChanges, OnDestroy {
         }),
         distinctUntilChanged(),
         startWith('Loading ...'),
-        throttleTime(100, asyncScheduler, { leading: true, trailing: true })
+        throttleTime(100, asyncScheduler, { leading: true, trailing: true }),
+        shareReplay(1),
       ))
     )
 

--- a/src/ui/nehubaContainer/nehubaContainer.template.html
+++ b/src/ui/nehubaContainer/nehubaContainer.template.html
@@ -20,13 +20,13 @@
 
 <current-layout *ngIf="viewerLoaded" class="position-absolute w-100 h-100 d-block pe-none">
   <div class="w-100 h-100 position-relative" cell-i>
-    <ng-content *ngTemplateOutlet="ngPanelOverlayTmpl; context: { panelIndex: 0 }"></ng-content>
+    <ng-content *ngTemplateOutlet="ngPanelOverlayTmpl; context: { panelIndex: panelOrder$ | async | getNthElement : 0 | parseAsNumber }"></ng-content>
   </div>
   <div class="w-100 h-100 position-relative" cell-ii>
-    <ng-content *ngTemplateOutlet="ngPanelOverlayTmpl; context: { panelIndex: 1 }"></ng-content>
+    <ng-content *ngTemplateOutlet="ngPanelOverlayTmpl; context: { panelIndex: panelOrder$ | async | getNthElement : 1 | parseAsNumber }"></ng-content>
   </div>
   <div class="w-100 h-100 position-relative" cell-iii>
-    <ng-content *ngTemplateOutlet="ngPanelOverlayTmpl; context: { panelIndex: 2 }"></ng-content>
+    <ng-content *ngTemplateOutlet="ngPanelOverlayTmpl; context: { panelIndex: panelOrder$ | async | getNthElement : 2 | parseAsNumber }"></ng-content>
   </div>
   <div class="w-100 h-100 position-relative" cell-iv>
     <ng-content *ngTemplateOutlet="overlayPerspectiveTmpl"></ng-content>

--- a/src/ui/nehubaContainer/nehubaContainer.template.html
+++ b/src/ui/nehubaContainer/nehubaContainer.template.html
@@ -29,7 +29,7 @@
     <ng-content *ngTemplateOutlet="ngPanelOverlayTmpl; context: { panelIndex: panelOrder$ | async | getNthElement : 2 | parseAsNumber }"></ng-content>
   </div>
   <div class="w-100 h-100 position-relative" cell-iv>
-    <ng-content *ngTemplateOutlet="overlayPerspectiveTmpl"></ng-content>
+    <ng-content *ngTemplateOutlet="ngPanelOverlayTmpl; context: { panelIndex: panelOrder$ | async | getNthElement : 3 | parseAsNumber }"></ng-content>
   </div>
 </current-layout>
 
@@ -579,49 +579,49 @@
 
 <!-- overlay templates -->
 
-<!-- perspective view tmpl -->
-<ng-template #overlayPerspectiveTmpl>
-  <layout-floating-container class="tmp" landmarkContainer>
-
-    <div class="d-flex flex-column justify-content-center align-items-center w-100 h-100 position-absolute opacity-crossfade screen-overlay pe-none"
-      [ngClass]="{onHover: !!(showPerpsectiveScreen$ | async)}"
-      [attr.id]="ID_MESH_LOADING_STATUS"
-      role="status">
-
-      <spinner-cmp *ngIf="showPerpsectiveScreen$ | async">
-      </spinner-cmp>
-      
-      <mat-list>
-        <mat-list-item>
-          {{ showPerpsectiveScreen$ | async }}
-        </mat-list-item>
-      </mat-list>
-    </div>
-
-    <!-- maximise/minimise button -->
-    <ng-container *ngTemplateOutlet="panelCtrlTmpl; context: {
-      panelIndex: panelOrder$ | async | getNthElement : 3 | parseAsNumber,
-      visible: (panelOrder$ | async | reorderPanelIndexPipe : ( hoveredPanelIndices$ | async )) === 3
-    }">
-    </ng-container>
-
-    <!-- mesh loading is still weird -->
-    <!-- if the precomputed server does not have the necessary fragment file, then the numberws will not collate -->
-    <div *ngIf="false && (perspectiveViewLoading$ | async)" class="loadingIndicator">
-      <spinner-cmp></spinner-cmp>
-
-      <div *ngIf="false" perspectiveLoadingText>
-        {{ perspectiveViewLoading$ | async }}
-      </div>
-    </div>
-  </layout-floating-container>
-</ng-template>
-
 <!-- slice view overlay tmpl -->
 <ng-template #ngPanelOverlayTmpl let-panelIndex="panelIndex">
 
+  <!-- perspective view tmpl -->
+  <ng-template #overlayPerspectiveTmpl>
+    <layout-floating-container class="tmp" landmarkContainer>
+
+      <div class="d-flex flex-column justify-content-center align-items-center w-100 h-100 position-absolute opacity-crossfade screen-overlay pe-none"
+        [ngClass]="{onHover: !!(showPerpsectiveScreen$ | async)}"
+        [attr.id]="ID_MESH_LOADING_STATUS"
+        role="status">
+
+        <spinner-cmp *ngIf="showPerpsectiveScreen$ | async">
+        </spinner-cmp>
+        
+        <mat-list>
+          <mat-list-item>
+            {{ showPerpsectiveScreen$ | async }}
+          </mat-list-item>
+        </mat-list>
+      </div>
+
+      <!-- maximise/minimise button -->
+      <ng-container *ngTemplateOutlet="panelCtrlTmpl; context: {
+        panelIndex: panelIndex,
+        visible: (hoveredPanelIndices$ | async) === panelIndex
+      }">
+      </ng-container>
+
+      <!-- mesh loading is still weird -->
+      <!-- if the precomputed server does not have the necessary fragment file, then the numberws will not collate -->
+      <div *ngIf="false && (perspectiveViewLoading$ | async)" class="loadingIndicator">
+        <spinner-cmp></spinner-cmp>
+
+        <div *ngIf="false" perspectiveLoadingText>
+          {{ perspectiveViewLoading$ | async }}
+        </div>
+      </div>
+    </layout-floating-container>
+  </ng-template>
+
   <!-- nb this slice view is not suitable for perspective view! -->
-  <layout-floating-container *ngIf="panelIndex < 3" landmarkContainer>
+  <layout-floating-container *ngIf="panelIndex < 3; else overlayPerspectiveTmpl" landmarkContainer>
 
     <!-- customLandmarks -->
     <nehuba-2dlandmark-unit *ngFor="let lm of (customLandmarks$ | async | filterByProperty : 'showInSliceView')"
@@ -649,8 +649,8 @@
 
     <!-- maximise/minimise button -->
     <ng-container *ngTemplateOutlet="panelCtrlTmpl; context: {
-      panelIndex: panelOrder$ | async | getNthElement : panelIndex | parseAsNumber,
-      visible: (panelOrder$ | async | reorderPanelIndexPipe : ( hoveredPanelIndices$ | async )) === panelIndex
+      panelIndex: panelIndex,
+      visible: (hoveredPanelIndices$ | async) === panelIndex
     }">
     </ng-container>
 
@@ -658,6 +658,7 @@
       <spinner-cmp></spinner-cmp>
     </div>
   </layout-floating-container>
+
 </ng-template>
 
 <!-- panel control template -->


### PR DESCRIPTION
currently, 3D landmarks rendered on slice views are not updated on the possible shuffled order (based on panel maximisation and in the future, panel rearrangement)

edit: casing point:

(maximised perspective view)

![Screenshot from 2020-12-01 13-03-33](https://user-images.githubusercontent.com/19381783/100738300-abe69c80-33d5-11eb-99f3-4edce8c4ff86.png)
