### PR TITLE
bugfix: explore in other tmpl bug

### DIFF
--- a/docs/releases/v2.3.9.md
+++ b/docs/releases/v2.3.9.md
@@ -1,0 +1,5 @@
+# v2.3.9
+
+## Bugfixes
+
+- Explore in other templates sometimes bugs out.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ pages:
     - Fetching datasets: 'advanced/datasets.md'
     - Display non-atlas volumes: 'advanced/otherVolumes.md'
   - Release notes:
+    - v2.3.9: 'releases/v2.3.9.md'
     - v2.3.8: 'releases/v2.3.8.md'
     - v2.3.7: 'releases/v2.3.7.md'
     - v2.3.6: 'releases/v2.3.6.md'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interactive-viewer",
-  "version": "2.3.8",
+  "version": "2.3.9",
   "description": "HBP interactive atlas viewer. Integrating KG query, dataset previews & more. Based on humanbrainproject/nehuba & google/neuroglancer. Built with angular.io",
   "scripts": {
     "dev-server-export": "webpack-dev-server --config webpack.export.js",

--- a/src/res/ext/bigbrain.json
+++ b/src/res/ext/bigbrain.json
@@ -852,7 +852,6 @@
                           "ngId": "v3v",
                           "status": "fully mapped",
                           "labelIndex": 1,
-                          "position": [],
                           "rgb": [
                             83,
                             179,
@@ -908,7 +907,6 @@
                               "ngId": "v5",
                               "status": "fully mapped",
                               "labelIndex": 1,
-                              "position": [],
                               "rgb": [
                                 255,
                                 0,
@@ -962,7 +960,6 @@
                               "ngId": "LGB-lam1",
                               "status": "fully mapped",
                               "labelIndex": 1,
-                              "position": [],
                               "rgb": [
                                 255,
                                 255,
@@ -991,7 +988,6 @@
                               "ngId": "LGB-lam2",
                               "status": "fully mapped",
                               "labelIndex": 1,
-                              "position": [],
                               "rgb": [
                                 222,
                                 74,
@@ -1020,7 +1016,6 @@
                               "ngId": "LGB-lam3",
                               "status": "fully mapped",
                               "labelIndex": 1,
-                              "position": [],
                               "rgb": [
                                 132,
                                 90,
@@ -1049,7 +1044,6 @@
                               "ngId": "LGB-lam4",
                               "status": "fully mapped",
                               "labelIndex": 1,
-                              "position": [],
                               "rgb": [
                                 41,
                                 123,
@@ -1078,7 +1072,6 @@
                               "ngId": "LGB-lam5",
                               "status": "fully mapped",
                               "labelIndex": 1,
-                              "position": [],
                               "rgb": [
                                 82,
                                 214,
@@ -1107,7 +1100,6 @@
                               "ngId": "LGB-lam6",
                               "status": "fully mapped",
                               "labelIndex": 1,
-                              "position": [],
                               "rgb": [
                                 99,
                                 231,
@@ -1141,7 +1133,6 @@
                               "ngId": "v5",
                               "status": "fully mapped",
                               "labelIndex": 1,
-                              "position": [],
                               "rgb": [
                                 255,
                                 0,
@@ -1186,7 +1177,6 @@
                               "ngId": "LGB-lam1",
                               "status": "fully mapped",
                               "labelIndex": 1,
-                              "position": [],
                               "rgb": [
                                 255,
                                 255,
@@ -1206,7 +1196,6 @@
                               "ngId": "LGB-lam2",
                               "status": "fully mapped",
                               "labelIndex": 1,
-                              "position": [],
                               "rgb": [
                                 222,
                                 74,
@@ -1226,7 +1215,6 @@
                               "ngId": "LGB-lam3",
                               "status": "fully mapped",
                               "labelIndex": 1,
-                              "position": [],
                               "rgb": [
                                 132,
                                 90,
@@ -1246,7 +1234,6 @@
                               "ngId": "LGB-lam4",
                               "status": "fully mapped",
                               "labelIndex": 1,
-                              "position": [],
                               "rgb": [
                                 41,
                                 123,
@@ -1266,7 +1253,6 @@
                               "ngId": "LGB-lam5",
                               "status": "fully mapped",
                               "labelIndex": 1,
-                              "position": [],
                               "rgb": [
                                 82,
                                 214,
@@ -1286,7 +1272,6 @@
                               "ngId": "LGB-lam6",
                               "status": "fully mapped",
                               "labelIndex": 1,
-                              "position": [],
                               "rgb": [
                                 99,
                                 231,

--- a/src/ui/parcellationRegion/region.base.spec.ts
+++ b/src/ui/parcellationRegion/region.base.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing'
 import { MockStore, provideMockStore } from '@ngrx/store/testing'
+import { viewerStateNewViewer } from 'src/services/state/viewerState/actions'
 import { RegionBase, regionInOtherTemplateSelector, getRegionParentParcRefSpace } from './region.base'
 
 /**
@@ -449,19 +450,20 @@ describe('> region.base.ts', () => {
   })
   
   describe('> RegionBase', () => {
+    let regionBase: RegionBase
+    let mockStore: MockStore
     beforeEach(() => {
       TestBed.configureTestingModule({
         providers: [
           provideMockStore()
         ]
       })
+      mockStore = TestBed.inject(MockStore)
+      mockStore.overrideSelector(regionInOtherTemplateSelector, [])
+      mockStore.overrideSelector(getRegionParentParcRefSpace, { template: null, parcellation: null })
     })
     describe('> position', () => {
-      let regionBase: RegionBase
       beforeEach(() => {
-        const mockStore = TestBed.inject(MockStore)
-        mockStore.overrideSelector(regionInOtherTemplateSelector, [])
-        mockStore.overrideSelector(getRegionParentParcRefSpace, { template: null, parcellation: null })
         regionBase = new RegionBase(mockStore)
       })
       it('> does not populate if position property is absent', () => {
@@ -524,6 +526,86 @@ describe('> region.base.ts', () => {
           position: [1, 2, 3]
         }
         expect(regionBase.position).toBeTruthy()
+      })
+    })
+  
+    describe('> changeView', () => {
+      const fakeTmpl = {
+        name: 'fakeTmpl'
+      }
+      const fakeParc = {
+        name: 'fakeParc'
+      }
+      beforeEach(() => {
+        regionBase = new RegionBase(mockStore)
+      })
+
+      describe('> if sameRegion has position attribute', () => {
+        let dispatchSpy: jasmine.Spy
+
+        beforeEach(() => {
+          dispatchSpy = spyOn(mockStore, 'dispatch')
+        })
+        afterEach(() => {
+          dispatchSpy.calls.reset()
+        })
+        it('> malformed position is not an array > do not pass position', () => {
+
+          regionBase.changeView({
+            template: fakeTmpl,
+            parcellation: fakeParc,
+            region: {
+              position: 'hello wolrd'
+            }
+          })
+
+          expect(dispatchSpy).toHaveBeenCalledWith(
+            viewerStateNewViewer({
+              selectTemplate: fakeTmpl,
+              selectParcellation: fakeParc,
+              navigation: {}
+            })
+          )
+        })
+
+        it('> malformed position is an array of incorrect size > do not pass position', () => {
+
+          regionBase.changeView({
+            template: fakeTmpl,
+            parcellation: fakeParc,
+            region: {
+              position: []
+            }
+          })
+
+          expect(dispatchSpy).toHaveBeenCalledWith(
+            viewerStateNewViewer({
+              selectTemplate: fakeTmpl,
+              selectParcellation: fakeParc,
+              navigation: {}
+            })
+          )
+        })
+
+        it('> correct position > pass position', () => {
+          regionBase.changeView({
+            template: fakeTmpl,
+            parcellation: fakeParc,
+            region: {
+              position: [1,2,3]
+            }
+          })
+
+          expect(dispatchSpy).toHaveBeenCalledWith(
+            viewerStateNewViewer({
+              selectTemplate: fakeTmpl,
+              selectParcellation: fakeParc,
+              navigation: {
+                position: [1,2,3]
+              }
+            })
+          )
+        })
       })
     })
   })

--- a/src/ui/parcellationRegion/region.base.ts
+++ b/src/ui/parcellationRegion/region.base.ts
@@ -169,6 +169,9 @@ export class RegionBase {
       region
     } = sameRegion
     const { position } = region
+    const navigation = Array.isArray(position) && position.length === 3
+      ? { position }
+      : {  }
     this.closeRegionMenu.emit()
 
     /**
@@ -178,9 +181,7 @@ export class RegionBase {
     this.store$.dispatch(viewerStateNewViewer ({
       selectTemplate: template,
       selectParcellation: parcellation,
-      navigation: {
-        position
-      },
+      navigation,
     }))
   }
 


### PR DESCRIPTION
bugfix, report from anna:

to reproduce:

0/ go to `/?templateSelected=MNI+152+ICBM+2009c+Nonlinear+Asymmetric&parcellationSelected=Cytoarchitectonic+Maps+-+v2.5.1&cRegionsSelected=%7B%22MNI152_V25_LEFT_NG_SPLIT_HEMISPHERE%22%3A%22U%22%7D&cNavigation=0.0.0.-W000..2_ZG29.-ASCS.2-8jM2._aAY3..DMVW..1CKBK%7E.59_Yu%7E.drVe%7E..45jd`
1/ `Explore in other tmpl` > `Big Brain`

expected behaviour: show big brain
actual behaviour: blank screen, with `NaN` as position of view